### PR TITLE
Add a geom-check to the trigger linking deceased with units

### DIFF
--- a/datamodel/app/sql_functions/geometry_functions.sql
+++ b/datamodel/app/sql_functions/geometry_functions.sql
@@ -14,7 +14,7 @@ BEGIN
     -- Check if deceasec has a geometry, otherwise do not update anything
     IF NEW.the_geom IS NULL
         THEN RETURN NEW;
-    ELSE 
+    ELSE
     END IF;
 
     -- Search for a unit polygon that contains the point in NEW.the_geom


### PR DESCRIPTION
This is a change requested by Kay Korrodi from Zermatt:

Since they do not plan to keep geometries for the deceased, they were unable to manually connect the deceased with any graves.
What would happen is, that the trigger would override any connection made by hand.

This fixes that through checking if the `NEW` record even has a geometry. If not, the trigger simlply fizzles out.
Since this does not interfere with the base functionality, we figured we would ask you to incorporate this change in main.